### PR TITLE
🐛 fix export for firefox

### DIFF
--- a/aurelia_project/aurelia.json
+++ b/aurelia_project/aurelia.json
@@ -182,7 +182,8 @@
             "name": "mustache",
             "path": "../node_modules/mustache",
             "main": "mustache.js"
-          }
+          },
+          "downloadjs"
         ]
       }
     ],

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bluebird": "^3.4.1",
     "bootstrap": "^3.3.7",
     "bpmn-js": "^0.21.0",
+    "downloadjs": "^1.4.7",
     "faye": "^1.2.4",
     "font-awesome": "^4.7.0",
     "jquery": "^2.2.4",

--- a/src/modules/processdef-detail/processdef-detail.ts
+++ b/src/modules/processdef-detail/processdef-detail.ts
@@ -1,6 +1,7 @@
 import {IProcessDefEntity} from '@process-engine/process_engine_contracts';
 import {EventAggregator, Subscription} from 'aurelia-event-aggregator';
 import {bindable, computedFrom, inject} from 'aurelia-framework';
+import * as download from 'downloadjs';
 import {AuthenticationStateEvent, IChooseDialogOption, IProcessEngineService} from '../../contracts/index';
 import environment from '../../environment';
 import {BpmnIo} from '../bpmn-io/bpmn-io';
@@ -118,16 +119,7 @@ export class ProcessDefDetail {
     this.exportButton.setAttribute('disabled', '');
     this.exportSpinner.classList.remove('hidden');
     this.bpmn.getXML().then((xml: any) => {
-      this.uri = 'data:application/bpmn20-xml;charset=UTF-8,' + encodeURI(xml);
-      this.name = 'Diagram.xml';
-      const atag: HTMLAnchorElement = document.createElement('a');
-      atag.setAttribute('href', this.uri);
-      atag.setAttribute('id', 'exportxml');
-      atag.setAttribute('download', this.name);
-      atag.setAttribute('hidden', 'true');
-      const appendedATag: HTMLAnchorElement = document.body.appendChild(atag);
-      appendedATag.click();
-      appendedATag.parentNode.removeChild(appendedATag);
+      download(xml, 'Diagram.xml', 'application/bpmn20-xml');
       this.exportButton.removeAttribute('disabled');
       this.exportSpinner.classList.add('hidden');
     });


### PR DESCRIPTION
## What did you change?

I replaced the manual file-export to use [download.js](https://www.npmjs.com/package/downloadjs) instead. This fixes #25 

## How can others test the changes?

You should (with this fix) be able to export diagrams with special characters using Firefox

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
