### PR TITLE
:lipstick: Switch from BindingEngine to @observable and set CreatePro…

### DIFF
--- a/src/modules/process-list/process-list.ts
+++ b/src/modules/process-list/process-list.ts
@@ -1,6 +1,6 @@
 import {INodeInstanceEntity} from '@process-engine/process_engine_contracts';
 import {EventAggregator, Subscription} from 'aurelia-event-aggregator';
-import {BindingEngine, inject} from 'aurelia-framework';
+import {inject, observable} from 'aurelia-framework';
 import {
   AuthenticationStateEvent,
   IPagination,
@@ -13,12 +13,11 @@ interface IProcessListRouteParameters {
   processDefId?: string;
 }
 
-@inject('ProcessEngineService', EventAggregator, BindingEngine)
+@inject('ProcessEngineService', EventAggregator)
 export class ProcessList {
 
   private processEngineService: IProcessEngineService;
   private eventAggregator: EventAggregator;
-  private bindingEngine: BindingEngine;
   private selectedState: HTMLSelectElement;
   private getProcessesIntervalId: number;
   private getProcesses: () => Promise<IPagination<IProcessEntity>>;
@@ -27,18 +26,19 @@ export class ProcessList {
   private instances: Array<IProcessEntity>;
   private status: Array<string> = [];
 
-  public currentPage: number = 0;
+  @observable public currentPage: number = 0;
   public pageSize: number = 10;
   public totalItems: number;
 
-  constructor(processEngineService: IProcessEngineService, eventAggregator: EventAggregator, bindingEngine: BindingEngine) {
+  constructor(processEngineService: IProcessEngineService, eventAggregator: EventAggregator) {
     this.processEngineService = processEngineService;
     this.eventAggregator = eventAggregator;
-    this.bindingEngine = bindingEngine;
+  }
 
-    this.bindingEngine.propertyObserver(this, 'currentPage').subscribe((newValue: number, oldValue: number) => {
+  public currentPageChanged(newValue: number, oldValue: number): void {
+    if (oldValue !== undefined && oldValue !== null) {
       this.updateProcesses();
-    });
+    }
   }
 
   public activate(routeParameters: IProcessListRouteParameters): void {


### PR DESCRIPTION
…cess-Button only once

## What did you change?

Switching from bindingengine to observable (aurelia-framework) to listen on change event.
The CreateProcess-Button is now only set once, because the wrong usertask was rendered if several usertasks of process key `CreateProcessDef` were available.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
