### PR TITLE
✨ Add radiobuttons for dynamic ui

### DIFF
--- a/src/modules/dynamic-ui-radiobutton-element/dynamic-ui-radiobutton-element.html
+++ b/src/modules/dynamic-ui-radiobutton-element/dynamic-ui-radiobutton-element.html
@@ -1,0 +1,10 @@
+<template>
+  <require from="./dynamic-ui-radiobutton-element.css"></require>
+  <label for="dynamic-${field.id}">${field.label}:</label>
+  <fieldset class="form-control" id="dynamic-${field.id}">
+    <span repeat.for="value of field.enumValues">
+      <input type="radio" id="dynamic-radio-${value.value}" name="${field.id}" model.bind="value.value" checked.bind="field.value">
+      <label for="dynamic-radio-${value.value}"> ${value.label}</label>
+    </span>
+  </fieldset>
+</template>

--- a/src/modules/dynamic-ui-radiobutton-element/dynamic-ui-radiobutton-element.html
+++ b/src/modules/dynamic-ui-radiobutton-element/dynamic-ui-radiobutton-element.html
@@ -1,7 +1,7 @@
 <template>
   <require from="./dynamic-ui-radiobutton-element.css"></require>
   <label for="dynamic-${field.id}">${field.label}:</label>
-  <fieldset class="form-control" id="dynamic-${field.id}">
+  <fieldset id="dynamic-${field.id}">
     <span repeat.for="value of field.enumValues">
       <input type="radio" id="dynamic-radio-${value.value}" name="${field.id}" model.bind="value.value" checked.bind="field.value">
       <label for="dynamic-radio-${value.value}"> ${value.label}</label>

--- a/src/modules/dynamic-ui-radiobutton-element/dynamic-ui-radiobutton-element.ts
+++ b/src/modules/dynamic-ui-radiobutton-element/dynamic-ui-radiobutton-element.ts
@@ -1,0 +1,15 @@
+import {IFormWidgetEnumField} from '@process-engine/consumer_client';
+import {bindable} from 'aurelia-framework';
+
+export class DynamicUiRadioButtonElement {
+
+  @bindable()
+  public field: IFormWidgetEnumField;
+
+  public activate(field: IFormWidgetEnumField): void {
+    this.field = field;
+    if (this.field.value === undefined || this.field.value === null || this.field.value === '') {
+      this.field.value = this.field.defaultValue;
+    }
+  }
+}


### PR DESCRIPTION
## What did you change?

Fixes #51, this pr just _adds_ support for rendering radiobuttons but this is never used currently.
Currently we can only know what _type_ the field to render is, e.g. `enum` in this case. We need a second flag for the prefered control to use. This need to be added into the consumer client. See https://github.com/process-engine/consumer_client/issues/7.

## How can others test the changes?

Change `dropdown` to `radiobutton` in `src/modules/form-widget/form-widget.ts`, when try to render some enum field. It will be rendered using checkboxes instead of a dropbown.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
