### PR TITLE
🐛 fix usage of incompatible types

### DIFF
--- a/src/modules/processdef-list/processdef-list.ts
+++ b/src/modules/processdef-list/processdef-list.ts
@@ -1,5 +1,4 @@
-import {ConsumerClient, IPagination, IUserTaskConfig} from '@process-engine/consumer_client';
-import {IProcessDefEntity} from '@process-engine/process_engine_contracts';
+import {ConsumerClient, IPagination, IProcessDefEntity, IUserTaskConfig} from '@process-engine/consumer_client';
 import {EventAggregator, Subscription} from 'aurelia-event-aggregator';
 import {inject, observable} from 'aurelia-framework';
 import {Router} from 'aurelia-router';

--- a/src/modules/task-list/task-list.ts
+++ b/src/modules/task-list/task-list.ts
@@ -2,11 +2,11 @@ import {
   IConfirmWidgetConfig,
   IConsumerClient,
   IUserTaskConfig,
+  IUserTaskEntity,
   UserTaskProceedAction,
   WidgetConfig,
   WidgetType,
 } from '@process-engine/consumer_client';
-import {IUserTaskEntity} from '@process-engine/process_engine_contracts';
 import {EventAggregator, Subscription} from 'aurelia-event-aggregator';
 import {bindable, computedFrom, inject} from 'aurelia-framework';
 import {AuthenticationStateEvent, IDynamicUiService, IPagination, IProcessEngineService} from '../../contracts/index';


### PR DESCRIPTION
## What did you change?

The consumer_client exports all Interfaces that are needed to use it. This means that the consumer_client imports some interfaces from essential-projects and process-engine and reexports them.

Charon used some interfaces from essential-projects and process-engine packets directly that were also exported from the consumer_client, but the version charon used was not necessarily identical to the interface-versions that are used by the consumer_client. This lead to build-errors, because multiple differing types of the same name were used within a single class.

This Branch fixes these build-errors

## How can others test the changes?

When checking out charon on this branch, you should be able to successfully build it without warnings or errors

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
