### PR TITLE
Enable Confirm Widget to render html in message

### DIFF
--- a/src/modules/confirm-widget/confirm-widget.html
+++ b/src/modules/confirm-widget/confirm-widget.html
@@ -1,5 +1,5 @@
 <template>
   <require from="./confirm-widget.css"></require>
-  <label>${widget.message}</label> 
+    <div id="renderHtml" innerhtml.bind="widget.message"></div>
   <br>
 </template>

--- a/src/modules/confirm-widget/confirm-widget.html
+++ b/src/modules/confirm-widget/confirm-widget.html
@@ -1,5 +1,5 @@
 <template>
   <require from="./confirm-widget.css"></require>
-    <div id="renderHtml" innerhtml.bind="widget.message"></div>
+  <div innerhtml.bind="widget.message"></div>
   <br>
 </template>


### PR DESCRIPTION
## What did you change?

This branch enables the confirm widget ALL html that is passed into it by the "message" property.
Example:

In:
```
First Line.<br>Second Line.
```

Out:
```
First Line.
Second Line.
```

Closes #70 

## How can others test the changes?

Create a new process with one user task with properties:

uiName
`Confirm`

uiConfig
`${ "message": "First Line.<br>Second Line.", "layout": [ { "key": "confirm", "label": "Confirm"}] };`

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
