### PR TITLE
🔥Delete "Stop Process"-Button

### DIFF
--- a/src/modules/process-list/process-list.html
+++ b/src/modules/process-list/process-list.html
@@ -14,16 +14,12 @@
                 <option repeat.for="state of status" value="${state}">${state}</option>
               </select>
             </th>
-            <th></th>
           </tr>
           <tr repeat.for="instance of shownProcesses">
             <td><a href="#/processdef/${instance.processDef.id}/detail">${instance.processDef.name}</a></td>
             <td>${instance.key}</td>
             <td>${instance.id}</td>
             <td><a href="#/process/${instance.id}/task">${instance.status}</a></td>
-            <td>
-              <a class="btn btn-danger" click.delegate="doCancel(instance.id)" disabled>Stop</a>
-            </td>
           </tr>
         </table>
     </div>

--- a/src/modules/process-list/process-list.ts
+++ b/src/modules/process-list/process-list.ts
@@ -109,10 +109,6 @@ export class ProcessList {
     return this.processes.data;
   }
 
-  public doCancel(instanceId: string): void {
-    //
-  }
-
   private async getAllProcesses(): Promise<IPagination<IProcessEntity>> {
     return this.processEngineService.getProcesses();
   }


### PR DESCRIPTION
## What did you change?

This branch deletes the disabled button for stopping process instances in the Process-List view.

Closes #34 

## How can others test the changes?

Switch to this branch and start Charon with `npm install`and `npm start`.
Navigate to `localhost:9000` and click on "Process Instance List" in the navbar.
You will see, there is no stop button anymore.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
