### PR TITLE
🐛 Instead of Relying on http-server, we now use our own Start Script

### DIFF
--- a/bin/charon.js
+++ b/bin/charon.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+const server = require('node-http-server');
+const open = require('open');
+const argv = require('minimist')(process.argv.slice(2)); 
+argv['root'] = __dirname + '/..';
+
+server.deploy(argv, (result) => {
+  const url = `http://localhost:${result.config.port}/`;
+  console.log(`Charon started at ${url}`);
+  console.log(`Press CRTL+C to exit.`);
+  open(url);
+});

--- a/bin/charon.js
+++ b/bin/charon.js
@@ -2,7 +2,8 @@
 
 const server = require('node-http-server');
 const open = require('open');
-const argv = require('minimist')(process.argv.slice(2)); 
+const argv = require('minimist')(process.argv.slice(2));
+
 argv['root'] = __dirname + '/..';
 
 server.deploy(argv, (result) => {

--- a/package.json
+++ b/package.json
@@ -16,14 +16,16 @@
     "scripts",
     "index.html"
   ],
-  "bin": "node_modules/.bin/http-server",
+  "bin": "./bin/charon.js",
   "repository": {
     "type": "???",
     "url": "???"
   },
   "license": "MIT",
   "dependencies": {
-    "http-server": "^0.10.0"
+    "minimist": "^1.2.0",
+    "node-http-server": "^8.1.2",
+    "open": "0.0.5"
   },
   "peerDependencies": {},
   "devDependencies": {


### PR DESCRIPTION
## What did you change?

This was needed because http-server would always serve the current working directory.
With our own script we can customize the root directory used to serve content.

## How can others test the changes?

- clone charon
- run `npm install`
- run `npm run build`
- run `npm install -g`
- run `charon` in _any_ folder

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
