### PR TITLE
:bug: Fix glyphicons and change start script

### DIFF
--- a/bin/charon.js
+++ b/bin/charon.js
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 
 const server = require('node-http-server');
+const config = new server.Config;
 const open = require('open');
-const argv = require('minimist')(process.argv.slice(2));
 
-argv['root'] = __dirname + '/..';
+config.root = __dirname + '/..';
+config.contentType.woff2 = 'application/font-woff2';
+config.contentType.woff = 'application/font-woff';
+config.contentType.ttf = 'application/x-font-ttf';
 
-server.deploy(argv, (result) => {
+server.deploy(config, (result) => {
   const url = `http://localhost:${result.config.port}/`;
   console.log(`Charon started at ${url}`);
   console.log(`Press CRTL+C to exit.`);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "minimist": "^1.2.0",
     "node-http-server": "^8.1.2",
     "open": "0.0.5",
     "electron": "^1.7.9"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The process-engine frontend.",
   "version": "1.0.0-rc5",
   "scripts": {
-    "start": "node-http-server port=9000",
+    "start": "./bin/charon.js",
     "start_dev": "au run --watch",
     "build": "au build --prod",
     "deploy": "npm run build && npm publish",


### PR DESCRIPTION
## What did you change?

This PR adds the glyphicon-config for the node-http-server and removes minimist from the package.json.
Minimist is no longer needed, because node-http-server checks the command line arguments by itself.

## How can others test the changes?

Checkout the branch and start charon with `npm start`. Now the glyphicons are shown correctly.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
