### PR TITLE
🚸 :children_crossing: After Deleting a ProcessDef Navigate to Main Page

### DIFF
--- a/src/modules/processdef-detail/processdef-detail.ts
+++ b/src/modules/processdef-detail/processdef-detail.ts
@@ -97,6 +97,7 @@ export class ProcessDefDetail {
     this.processEngineService.deleteProcessDef(this.process.id)
       .then(() => {
         this._process = null;
+        this.router.navigate('');
       })
       .catch((error: Error) => {
         alert(error.message);


### PR DESCRIPTION
## What did you change?

When deleting a processdef, charon now navigates back to the main page.

Closes #104

## How can others test the changes?

- Delete a processdef
- Main page should be displayed and the processdef deleted

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
